### PR TITLE
Make the algorithm work in the modeler setting the extent dynamically

### DIFF
--- a/OpenTopography_DEMDownloader_algorithm.py
+++ b/OpenTopography_DEMDownloader_algorithm.py
@@ -80,16 +80,16 @@ class OpenTopographyDEMDownloaderAlgorithm(QgsProcessingAlgorithm):
         outputs = {}
         
         # process extent bbox information
-        extent = parameters['Extent']
-        epsg = extent.split(' ')[1]
-        epsg = epsg[1:-1] # strip off [ ]
-        #print (epsg)
-        extent = extent.split(' ')[0].split(',')
-        south = extent[2]
-        north = extent[3]
-        west = extent[0]
-        east = extent[1]
-        if not(epsg=='EPSG:4326'):
+        crs = self.parameterAsExtentCrs(parameters, "Extent", context)
+        extent = self.parameterAsExtentGeometry(
+            parameters, "Extent", context
+        ).boundingBox()
+        epsg = crs.authid()
+        south = extent.yMinimum()
+        north = extent.yMaximum()
+        west = extent.xMinimum()
+        east = extent.xMaximum()
+        if epsg != "EPSG:4326":
             south_exp =  f'y(transform(make_point({west},{south}),\'{epsg}\',\'EPSG:4326\'))'
             west_exp =  f'x(transform(make_point({west},{south}),\'{epsg}\',\'EPSG:4326\'))'
             north_exp =  f'y(transform(make_point({east},{north}),\'{epsg}\',\'EPSG:4326\'))'


### PR DESCRIPTION
When using model input (e.g. vector layer) as source for the extent, the QGIS processing framework sets the string value (the one available in `parameters['extent']` to the layer id. However, the code in this plugin assumes it will be a list of coordinates as it shown when using manually. Luckily, the processing framework deals the layer id values correctly when you pass them to `parameterAsExtentGeometry` and `parameterAsExtentCrs`.

Fix #1 